### PR TITLE
Generalize collapse function

### DIFF
--- a/phippery/__init__.py
+++ b/phippery/__init__.py
@@ -1,4 +1,4 @@
-# utils
+# dataset
 from phippery.phipdata import stitch_dataset
 from phippery.phipdata import dataset_to_csv
 from phippery.phipdata import load

--- a/phippery/collapse.py
+++ b/phippery/collapse.py
@@ -22,9 +22,181 @@ import itertools
 from phippery.utils import iter_sample_groups
 
 
-def collapse_sample_groups(
-    ds, group, agg_func=lambda x: np.mean(x, axis=1), compute_pw_cc=False
+def throw_mismatched_features(df: pd.DataFrame, by: list):
+    """
+    When you collapse by some set of columns in the dataframe,
+    keep only features which are shared by
+
+    This is similar to
+    """
+
+    # Find out which collapse features are shared within groups
+    collapsed_sample_metadata = defaultdict(list)
+    for i, (group, group_df) in enumerate(df.groupby(by)):
+        for column, value in group_df.iteritems():
+            v = value.values
+            if np.all(v == v[0]) or np.all([n != n for n in v]):
+                collapsed_sample_metadata[column].append(v[0])
+
+    # Throw out features that are not shared between groups
+    to_throw = [
+        key for key, value in collapsed_sample_metadata.items() if len(value) < i + 1
+    ]
+    [collapsed_sample_metadata.pop(key) for key in to_throw]
+    return pd.DataFrame(collapsed_sample_metadata)
+
+
+def collapse_groups(ds, by, table="sample", agg_func=np.mean, compute_pw_cc=False):
+    """
+    Collapse a phip xarray dataset by some group in the metadata.
+    """
+
+    # Check to see if the group(s) is/are available
+    groups_avail = ds[f"{table}_metadata"].values
+    for group in by:
+        if group not in groups_avail:
+            raise KeyError(
+                f"{group} is not included as a column in the {table} table. The available groups are {groups_avail}"
+            )
+
+    # grab relavent annotation tables
+    collapse_df = ds[f"{table}_table"].to_pandas()
+    tables = set(["sample_table", "peptide_table"])
+    fixed_var = list(tables - set([f"{table}_table"]))[0]
+
+    # Create group-able dataset by assigning table columns to a coordinate
+    if len(by) == 1:
+        coord = collapse_df[by[0]]
+        coord_ds = ds.assign_coords(coord=(f"{table}_id", coord))
+
+    # if were grouping by multiple things, we need to zip 'em into a tuple coord
+    else:
+        common_dim = f"{table}_id"
+        coor_arr = np.empty(len(ds[common_dim]), dtype=object)
+        coor_arr[:] = list(zip(*(collapse_df[f].values for f in by)))
+        coord_ds = ds.assign_coords(coord=xr.DataArray(coor_arr, dims=common_dim))
+
+    # save dat memory
+    del coord_ds["sample_table"]
+    del coord_ds["peptide_table"]
+    print(coord_ds)
+    print("YOOOOOOOOOOOOOOOOOOOO")
+
+    # perform the reduction
+    collapsed_enrichments = coord_ds.groupby("coord").reduce(agg_func).transpose()
+
+    # oce grouped, we have no use for first copy, delete
+    del coord_ds
+
+    # compile each of the collapsed xarray variables
+    collapsed_xr_dfs = {
+        f"{dt}": (
+            ["peptide_id", "sample_id"],
+            collapsed_enrichments[f"{dt}"].to_pandas(),
+        )
+        for dt in set(list(collapsed_enrichments.data_vars))
+    }
+
+    # get collapsed table
+    # TODO, you could also offer a "First" option here.
+    csm = throw_mismatched_features(collapse_df, by)
+
+    # Compute mean pairwise correlation for all groups,
+    # for all enrichment layers - and add it to the
+    # resulting collapsed sample table
+    # TODO, this could be
+    if compute_pw_cc:
+        for data_table in list(
+            set(ds.data_vars) - set(["sample_table", "peptide_table"])
+        ):
+            pw_cc = pairwise_correlation_by_sample_group(ds, by, data_table)
+            assert len(pw_cc) == len(csm)
+            csm = csm.merge(pw_cc, left_index=True, right_index=True)
+
+    # insert the correct annotation tables to
+    # NOTE AnnoTable.
+    collapsed_xr_dfs[f"{table}_table"] = (
+        [f"{table}_id", "sample_metadata"],
+        csm,
+    )
+
+    collapsed_xr_dfs[f"{fixed_var}"] = (
+        ["peptide_id", "peptide_metadata"],
+        ds[f"{fixed_var}"].to_pandas(),
+    )
+
+    pds = xr.Dataset(
+        collapsed_xr_dfs,
+        coords={
+            "sample_id": collapsed_xr_dfs["sample_table"][1].index.values,
+            "peptide_id": collapsed_xr_dfs["peptide_table"][1].index.values,
+            "sample_metadata": collapsed_xr_dfs["sample_table"][1].columns.values,
+            "peptide_metadata": collapsed_xr_dfs["peptide_table"][1].columns.values,
+        },
+    )
+    pds.attrs["collapsed_group"] = group
+    return pds
+
+
+def pairwise_correlation_by_group(
+    ds, group="sample_ID", data_table="counts", column_prefix=None
 ):
+    """
+    a method which computes pairwise cc for all
+    sample in a group specified by 'group' column.
+
+    returns a dataframe with each group, it's
+    repective pw_cc, and the number of samples
+    in the group.
+    """
+
+    if group not in ds.sample_metadata.values:
+        raise ValueError("{group} does not exist in sample metadata")
+
+    if data_table not in ds:
+        raise KeyError(f"{data_table} is not included in dataset.")
+
+    data = ds[f"{data_table}"].to_pandas()
+
+    groups, pw_cc, n = [], [], []
+    for s_group, group_ds in iter_sample_groups(ds, group):
+        groups.append(int(s_group))
+        n.append(len(group_ds["sample_id"].values))
+
+        if len(group_ds["sample_id"].values) < 2:
+            pw_cc.append(1.0)
+            continue
+        correlations = []
+        for sample_ids in itertools.combinations(group_ds["sample_id"].values, 2):
+            sample_0_enrichment = data.loc[:, sample_ids[0]]
+            sample_1_enrichment = data.loc[:, sample_ids[1]]
+            correlation = (
+                st.pearsonr(sample_0_enrichment, sample_1_enrichment)[0]
+                if np.any(sample_0_enrichment != sample_1_enrichment)
+                else 1.0
+            )
+            correlations.append(correlation)
+        pw_cc.append(round(sum(correlations) / len(correlations), 5))
+
+    if column_prefix is None:
+        column_prefix = f"{group}_{data_table}"
+
+    ret = pd.DataFrame(
+        {
+            f"{group}": groups,
+            f"{column_prefix}_pw_cc": np.array(pw_cc).astype(np.float64),
+            f"{column_prefix}_n_reps": np.array(n).astype(np.int),
+        }
+    ).set_index(group)
+
+    return ret
+
+
+####################################################
+####################################################
+
+
+def collapse_sample_groups(ds, group, agg_func=np.mean, compute_pw_cc=False):
     """
     Collapse a phip xarray dataset by some group in the metadata.
     """
@@ -34,10 +206,6 @@ def collapse_sample_groups(
             f"{group} is not included as a column in the sample table. The available groups are {ds.sample_metadata.values}"
         )
 
-    # FIXME
-    # right now, this asserts that the group being collapsed on should be an int
-    # instead, we could just reset the index I assume?
-
     try:
         coord = ds.sample_table.loc[:, group].values.astype(int)
     except ValueError:
@@ -46,9 +214,9 @@ def collapse_sample_groups(
         )
 
     coord_ds = ds.assign_coords(coord=("sample_id", coord))
-    collapsed_enrichments = (
-        coord_ds.groupby("coord").map(lambda x: agg_func(x),).transpose()
-    )
+    del coord_ds["sample_table"]
+    del coord_ds["peptide_table"]
+    collapsed_enrichments = coord_ds.groupby("coord").reduce(agg_func).transpose()
 
     collapsed_xr_dfs = {
         f"{dt}": (
@@ -76,8 +244,6 @@ def collapse_sample_groups(
     csm[group] = csm[group].astype(int)
     csm.set_index(group, inplace=True)
 
-    # FIXME
-    # This should compute the pw cc for each data table, no?
     if compute_pw_cc:
         for data_table in list(
             set(ds.data_vars) - set(["sample_table", "peptide_table"])
@@ -96,8 +262,6 @@ def collapse_sample_groups(
         ds.peptide_table.to_pandas(),
     )
 
-    # FIXME
-    # the type switch happens below - see line 157
     pds = xr.Dataset(
         collapsed_xr_dfs,
         coords={
@@ -154,7 +318,6 @@ def pairwise_correlation_by_sample_group(
     if column_prefix is None:
         column_prefix = f"{group}_{data_table}"
 
-    # FIXME WTF IS GOING ON WITH THE DATATYPES FROM INT/FLOAT to Object
     ret = pd.DataFrame(
         {
             f"{group}": groups,

--- a/phippery/collapse.py
+++ b/phippery/collapse.py
@@ -142,10 +142,13 @@ def mean_pw_cc_by(ds, by, data_table="counts", dim="sample"):
 
 
 def collapse_sample_groups(*args, **kwargs):
-    """
-    DEPRECATED - SEE COLLAPSE GROUPS
-    """
+    """wrap for sample collapse"""
     return collapse_groups(*args, **kwargs, collapse_dim="sample")
+
+
+def collapse_peptide_groups(*args, **kwargs):
+    """wrap for peptide collapse"""
+    return collapse_groups(*args, **kwargs, collapse_dim="peptide")
 
 
 def collapse_groups(
@@ -176,7 +179,7 @@ def collapse_groups(
     fixed_df = ds[f"{fixed_dim}_table"].to_pandas()
 
     # Create group-able dataset by assigning table columns to a coordinate
-    # TODO How do we re-name this according to the thing we're collapsing on???
+    # TODO
     if len(by) == 1:
         coord = collapse_df[by[0]]
         coord_ds = ds.assign_coords({f"{by[0]}": (f"{collapse_dim}_id", coord)})

--- a/phippery/collapse.py
+++ b/phippery/collapse.py
@@ -90,7 +90,6 @@ def mean_pw_cc_by_multiple_tables(ds, by, dim="sample", data_tables="all"):
     )
 
 
-# TODO - this needsd to be generalized as well.
 def mean_pw_cc_by(ds, by, data_table="counts", dim="sample"):
 
     """Computes pairwise cc for all
@@ -106,7 +105,7 @@ def mean_pw_cc_by(ds, by, data_table="counts", dim="sample"):
     groups, pw_cc, n = [], [], []
 
     for s_group, group_ds in iter_groups(ds, by, dim):
-        groups.append(int(s_group))
+        groups.append(s_group)
         n.append(len(group_ds[f"{dim}_id"].values))
 
         if len(group_ds[f"{dim}_id"].values) < 2:
@@ -233,9 +232,7 @@ def collapse_groups(
     # Compute mean pairwise correlation for all groups,
     # for all enrichment layers - and add it to the
     # resulting collapsed sample table
-    # TODO,
     if compute_pw_cc:
-        print(f"WARNING - ONLY ON SAMPLES ATM")
         mean_pw_cc = mean_pw_cc_by(ds, by, **kwargs)
         cat = cat.merge(mean_pw_cc, left_index=True, right_index=True)
 

--- a/phippery/collapse.py
+++ b/phippery/collapse.py
@@ -25,9 +25,13 @@ from phippery.utils import iter_sample_groups
 def throw_mismatched_features(df: pd.DataFrame, by: list):
     """
     When you collapse by some set of columns in the dataframe,
-    keep only features which are shared by
+    keep only features which homogeneous within groups.
 
-    This is similar to
+    This is similar to 'DataFrameGroupby.first()' method,
+    but instead of keeping the first factor level appearing for each group
+    category, we only throw any features which are note homogeneous within groups.
+    You could achieve the same functionality by listing features you know to be
+    homogeneous in the 'by' parameter.
     """
 
     # Find out which collapse features are shared within groups
@@ -46,49 +50,128 @@ def throw_mismatched_features(df: pd.DataFrame, by: list):
     return pd.DataFrame(collapsed_sample_metadata)
 
 
-def collapse_groups(ds, by, table="sample", agg_func=np.mean, compute_pw_cc=False):
+def mean_pw_correlation_by_group(ds, by, data_tables="all"):
+    """A wrapper for computing pw cc within groups defined
+    with the 'by' parameter. Merges the correlations into a
+    single table"""
+    # NOTE TODO
+
+    """
+    # Compute mean pw cc on all possible data tables
+    if data_tables == 'all':
+        data_tables = list(
+                set(ds.data_vars) - set(['sample_table', 'peptide_table'])
+                )
+
+    corr_tables = [
+        pairwise_correlation_by_sample_group(ds, by, data_table)
+        for data_table in data_tables
+    ]
+
+        #assert len(pw_cc) == len(csm)
+        collapsed_anno_table = collapsed_anno_table.merge(
+                pw_cc, left_index=True, right_index=True
+                )
+    """
+    pass
+
+
+def pairwise_correlation_by_group(ds, group, data_table="counts", column_prefix=None):
+
+    """Computes pairwise cc for all
+    sample in a group specified by 'group' column.
+
+    returns a dataframe with each group, it's
+    repective pw_cc, and the number of samples
+    in the group."""
+
+    # TODO, how could this
+
+    if group not in ds.sample_metadata.values:
+        raise ValueError(f"{group} does not exist in sample metadata")
+
+    if data_table not in ds:
+        raise KeyError(f"{data_table} is not included in dataset.")
+
+    data = ds[f"{data_table}"].to_pandas()
+
+    groups, pw_cc, n = [], [], []
+    for s_group, group_ds in iter_sample_groups(ds, group):
+        groups.append(int(s_group))
+        n.append(len(group_ds["sample_id"].values))
+
+        if len(group_ds["sample_id"].values) < 2:
+            pw_cc.append(1.0)
+            continue
+        correlations = []
+        for sample_ids in itertools.combinations(group_ds["sample_id"].values, 2):
+            sample_0_enrichment = data.loc[:, sample_ids[0]]
+            sample_1_enrichment = data.loc[:, sample_ids[1]]
+            correlation = (
+                st.pearsonr(sample_0_enrichment, sample_1_enrichment)[0]
+                if np.any(sample_0_enrichment != sample_1_enrichment)
+                else 1.0
+            )
+            correlations.append(correlation)
+        pw_cc.append(round(sum(correlations) / len(correlations), 5))
+
+    if column_prefix is None:
+        column_prefix = f"{group}_{data_table}"
+
+    ret = pd.DataFrame(
+        {
+            f"{group}": groups,
+            f"{column_prefix}_pw_cc": np.array(pw_cc).astype(np.float64),
+            f"{column_prefix}_n_reps": np.array(n).astype(np.int),
+        }
+    ).set_index(group)
+
+    return ret
+
+
+def collapse_groups(
+    ds, by, collapse_dim="sample", agg_func=np.mean, compute_pw_cc=False
+):
     """
     Collapse a phip xarray dataset by some group in the metadata.
     """
 
     # Check to see if the group(s) is/are available
-    groups_avail = ds[f"{table}_metadata"].values
+    groups_avail = ds[f"{collapse_dim}_metadata"].values
     for group in by:
         if group not in groups_avail:
             raise KeyError(
-                f"{group} is not included as a column in the {table} table. The available groups are {groups_avail}"
+                f"{group} is not included as a column in the {collapse_dim} table. The available groups are {groups_avail}"
             )
 
     # grab relavent annotation tables
-    collapse_df = ds[f"{table}_table"].to_pandas()
-    tables = set(["sample_table", "peptide_table"])
-    fixed_var = list(tables - set([f"{table}_table"]))[0]
+    collapse_df = ds[f"{collapse_dim}_table"].to_pandas()
 
     # Create group-able dataset by assigning table columns to a coordinate
     if len(by) == 1:
         coord = collapse_df[by[0]]
-        coord_ds = ds.assign_coords(coord=(f"{table}_id", coord))
+        coord_ds = ds.assign_coords(coord=(f"{collapse_dim}_id", coord))
 
     # if were grouping by multiple things, we need to zip 'em into a tuple coord
     else:
-        common_dim = f"{table}_id"
+        common_dim = f"{collapse_dim}_id"
         coor_arr = np.empty(len(ds[common_dim]), dtype=object)
         coor_arr[:] = list(zip(*(collapse_df[f].values for f in by)))
-        coord_ds = ds.assign_coords(coord=xr.DataArray(coor_arr, dims=common_dim))
+        coord_ds = ds.assign_coords(
+            coord=xr.DataArray(coor_arr, collapse_dims=common_dim)
+        )
 
-    # save dat memory
+    # Save dat memory, also, we will perform custom grouping's on the annotation tables
     del coord_ds["sample_table"]
     del coord_ds["peptide_table"]
-    print(coord_ds)
-    print("YOOOOOOOOOOOOOOOOOOOO")
 
-    # perform the reduction
+    # Perform the reduction on all data tables.
     collapsed_enrichments = coord_ds.groupby("coord").reduce(agg_func).transpose()
 
-    # oce grouped, we have no use for first copy, delete
+    # Once the data tables are grouped we have no use for first copy.
     del coord_ds
 
-    # compile each of the collapsed xarray variables
+    # Compile each of the collapsed xarray variables.
     collapsed_xr_dfs = {
         f"{dt}": (
             ["peptide_id", "sample_id"],
@@ -98,168 +181,30 @@ def collapse_groups(ds, by, table="sample", agg_func=np.mean, compute_pw_cc=Fals
     }
 
     # get collapsed table
-    # TODO, you could also offer a "First" option here.
-    csm = throw_mismatched_features(collapse_df, by)
+    # TODO, you could also offer a "first()" option here.
+    collapsed_anno_table = throw_mismatched_features(collapse_df, by)
 
     # Compute mean pairwise correlation for all groups,
     # for all enrichment layers - and add it to the
     # resulting collapsed sample table
-    # TODO, this could be
-    if compute_pw_cc:
-        for data_table in list(
-            set(ds.data_vars) - set(["sample_table", "peptide_table"])
-        ):
-            pw_cc = pairwise_correlation_by_sample_group(ds, by, data_table)
-            assert len(pw_cc) == len(csm)
-            csm = csm.merge(pw_cc, left_index=True, right_index=True)
+    # TODO, this could be slightly expensive, and possibly more
+    # well rounded.
+    # NOTE TODO
+    # if compute_pw_cc:
 
-    # insert the correct annotation tables to
+    dims = set(["sample", "peptide"])
+    fixed_dim = list(dims - set([collapse_dim]))[0]
+
+    # Insert the correct annotation tables to out dictionary of variables
     # NOTE AnnoTable.
-    collapsed_xr_dfs[f"{table}_table"] = (
-        [f"{table}_id", "sample_metadata"],
-        csm,
+    collapsed_xr_dfs[f"{collapse_dim}_table"] = (
+        [f"{collapse_dim}_id", "{dim}_metadata"],
+        collapsed_anno_table,
     )
 
-    collapsed_xr_dfs[f"{fixed_var}"] = (
-        ["peptide_id", "peptide_metadata"],
-        ds[f"{fixed_var}"].to_pandas(),
-    )
-
-    pds = xr.Dataset(
-        collapsed_xr_dfs,
-        coords={
-            "sample_id": collapsed_xr_dfs["sample_table"][1].index.values,
-            "peptide_id": collapsed_xr_dfs["peptide_table"][1].index.values,
-            "sample_metadata": collapsed_xr_dfs["sample_table"][1].columns.values,
-            "peptide_metadata": collapsed_xr_dfs["peptide_table"][1].columns.values,
-        },
-    )
-    pds.attrs["collapsed_group"] = group
-    return pds
-
-
-def pairwise_correlation_by_group(
-    ds, group="sample_ID", data_table="counts", column_prefix=None
-):
-    """
-    a method which computes pairwise cc for all
-    sample in a group specified by 'group' column.
-
-    returns a dataframe with each group, it's
-    repective pw_cc, and the number of samples
-    in the group.
-    """
-
-    if group not in ds.sample_metadata.values:
-        raise ValueError("{group} does not exist in sample metadata")
-
-    if data_table not in ds:
-        raise KeyError(f"{data_table} is not included in dataset.")
-
-    data = ds[f"{data_table}"].to_pandas()
-
-    groups, pw_cc, n = [], [], []
-    for s_group, group_ds in iter_sample_groups(ds, group):
-        groups.append(int(s_group))
-        n.append(len(group_ds["sample_id"].values))
-
-        if len(group_ds["sample_id"].values) < 2:
-            pw_cc.append(1.0)
-            continue
-        correlations = []
-        for sample_ids in itertools.combinations(group_ds["sample_id"].values, 2):
-            sample_0_enrichment = data.loc[:, sample_ids[0]]
-            sample_1_enrichment = data.loc[:, sample_ids[1]]
-            correlation = (
-                st.pearsonr(sample_0_enrichment, sample_1_enrichment)[0]
-                if np.any(sample_0_enrichment != sample_1_enrichment)
-                else 1.0
-            )
-            correlations.append(correlation)
-        pw_cc.append(round(sum(correlations) / len(correlations), 5))
-
-    if column_prefix is None:
-        column_prefix = f"{group}_{data_table}"
-
-    ret = pd.DataFrame(
-        {
-            f"{group}": groups,
-            f"{column_prefix}_pw_cc": np.array(pw_cc).astype(np.float64),
-            f"{column_prefix}_n_reps": np.array(n).astype(np.int),
-        }
-    ).set_index(group)
-
-    return ret
-
-
-####################################################
-####################################################
-
-
-def collapse_sample_groups(ds, group, agg_func=np.mean, compute_pw_cc=False):
-    """
-    Collapse a phip xarray dataset by some group in the metadata.
-    """
-
-    if group not in ds.sample_metadata.values:
-        raise KeyError(
-            f"{group} is not included as a column in the sample table. The available groups are {ds.sample_metadata.values}"
-        )
-
-    try:
-        coord = ds.sample_table.loc[:, group].values.astype(int)
-    except ValueError:
-        raise ValueError(
-            f"All factor level values in {group} must be able to convert to int"
-        )
-
-    coord_ds = ds.assign_coords(coord=("sample_id", coord))
-    del coord_ds["sample_table"]
-    del coord_ds["peptide_table"]
-    collapsed_enrichments = coord_ds.groupby("coord").reduce(agg_func).transpose()
-
-    collapsed_xr_dfs = {
-        f"{dt}": (
-            ["peptide_id", "sample_id"],
-            collapsed_enrichments[f"{dt}"].to_pandas(),
-        )
-        for dt in set(list(collapsed_enrichments.data_vars))
-    }
-
-    sample_table_df = ds.sample_table.to_pandas()
-    collapsed_sample_metadata = defaultdict(list)
-    for i, (tech_rep_id, tech_rep_meta) in enumerate(sample_table_df.groupby(group)):
-        for column, value in tech_rep_meta.iteritems():
-            v = value.values
-            if np.all(v == v[0]) or np.all([n != n for n in v]):
-                collapsed_sample_metadata[column].append(v[0])
-
-    to_throw = [
-        key for key, value in collapsed_sample_metadata.items() if len(value) < i + 1
-    ]
-
-    [collapsed_sample_metadata.pop(key) for key in to_throw]
-
-    csm = pd.DataFrame(collapsed_sample_metadata)
-    csm[group] = csm[group].astype(int)
-    csm.set_index(group, inplace=True)
-
-    if compute_pw_cc:
-        for data_table in list(
-            set(ds.data_vars) - set(["sample_table", "peptide_table"])
-        ):
-            pw_cc = pairwise_correlation_by_sample_group(ds, group, data_table)
-            assert len(pw_cc) == len(csm)
-            csm = csm.merge(pw_cc, left_index=True, right_index=True)
-
-    collapsed_xr_dfs["sample_table"] = (
-        ["sample_id", "sample_metadata"],
-        csm,
-    )
-
-    collapsed_xr_dfs["peptide_table"] = (
-        ["peptide_id", "peptide_metadata"],
-        ds.peptide_table.to_pandas(),
+    collapsed_xr_dfs[f"{fixed_dim}_table"] = (
+        ["{fixed_dim}_id", "{fixed_dim}_metadata"],
+        ds[f"{fixed_dim}_table"].to_pandas(),
     )
 
     pds = xr.Dataset(
@@ -273,57 +218,3 @@ def collapse_sample_groups(ds, group, agg_func=np.mean, compute_pw_cc=False):
     )
     pds.attrs["collapsed_group"] = group
     return pds
-
-
-def pairwise_correlation_by_sample_group(
-    ds, group="sample_ID", data_table="counts", column_prefix=None
-):
-    """
-    a method which computes pairwise cc for all
-    sample in a group specified by 'group' column.
-
-    returns a dataframe with each group, it's
-    repective pw_cc, and the number of samples
-    in the group.
-    """
-
-    if group not in ds.sample_metadata.values:
-        raise ValueError("{group} does not exist in sample metadata")
-
-    if data_table not in ds:
-        raise KeyError(f"{data_table} is not included in dataset.")
-
-    data = ds[f"{data_table}"].to_pandas()
-
-    groups, pw_cc, n = [], [], []
-    for s_group, group_ds in iter_sample_groups(ds, group):
-        groups.append(int(s_group))
-        n.append(len(group_ds["sample_id"].values))
-
-        if len(group_ds["sample_id"].values) < 2:
-            pw_cc.append(1.0)
-            continue
-        correlations = []
-        for sample_ids in itertools.combinations(group_ds["sample_id"].values, 2):
-            sample_0_enrichment = data.loc[:, sample_ids[0]]
-            sample_1_enrichment = data.loc[:, sample_ids[1]]
-            correlation = (
-                st.pearsonr(sample_0_enrichment, sample_1_enrichment)[0]
-                if np.any(sample_0_enrichment != sample_1_enrichment)
-                else 1.0
-            )
-            correlations.append(correlation)
-        pw_cc.append(round(sum(correlations) / len(correlations), 5))
-
-    if column_prefix is None:
-        column_prefix = f"{group}_{data_table}"
-
-    ret = pd.DataFrame(
-        {
-            f"{group}": groups,
-            f"{column_prefix}_pw_cc": np.array(pw_cc).astype(np.float64),
-            f"{column_prefix}_n_reps": np.array(n).astype(np.int),
-        }
-    ).set_index(group)
-
-    return ret

--- a/phippery/collapse.py
+++ b/phippery/collapse.py
@@ -77,14 +77,10 @@ def mean_pw_corr_by(ds, by, dim="sample", data_tables="all"):
             )
 
     # Compute mean pw cc on all data layers - resulting in a df for each
-    # print(f"YO")
     corr_dfs = [
         mean_pw_cc_by(ds, by, data_table=data_table, dim=dim)
         for data_table in data_tables
     ]
-    # corr_dfs = []
-    # for data_table in data_tables:
-    #    corr_dfs.append(mean_pw_cc_by(ds, by, data_table=data_table, dim=dim))
 
     # return a single merged df containing info for all data layer pw cc
     return reduce(
@@ -106,11 +102,6 @@ def mean_pw_cc_by(ds, by, data_table="counts", dim="sample"):
 
     # TODO Let's allocate mem right here instead of hefty appending.
     groups, pw_cc, n = [], [], []
-
-    # if kwargs["dim"] == "dim":
-    #    iter_func = iter_dim_groups
-    # elif kar
-    #    iter_func = iter_peptide_groups
 
     for s_group, group_ds in iter_groups(ds, by, dim):
         groups.append(int(s_group))

--- a/phippery/normalize.py
+++ b/phippery/normalize.py
@@ -437,7 +437,6 @@ def differential_selection_sample_groups(
         return ds_copy
 
 
-# def _comp_diff_sel(base, all_other_values, scaled_by_base=False):
 def _comp_diff_sel(base, all_other_values, scalar=1):
     """
     a private function to compute differential selection of one values to a list of other values. Optionally, you can scale each of the differential selection values by the base if desired.

--- a/phippery/utils.py
+++ b/phippery/utils.py
@@ -47,29 +47,51 @@ def get_all_peptide_metadata_factors(ds, feature):
     return [x for x in set(all_exp.values) if x == x]
 
 
-def iter_sample_groups(ds, groupby):
+def iter_groups(ds, by, dim="sample"):
     """
+    returns an iterator yeilding subsets of the provided dataset,
+    grouped by items in the metadata of either dimension.
+    """
+
+    table = ds[f"{dim}_table"].to_pandas()
+    for group, group_df in table.groupby(by):
+        group_ds = ds.loc[{f"{dim}_id": list(group_df.index.values)}]
+        # group_ds = ds.loc[dict(peptide_id=list(group_df.index.values))]
+        yield group, group_ds
+
+
+def iter_sample_groups(*args):
+    """
+    DEPRECATED - use 'iter_groups()' instead
+
     returns an iterator yeilding subsets of the provided dataset,
     grouped by an item on the sample metadata coodinate.
     """
-    sample_table = ds.sample_table.to_pandas().reset_index()
-    for group, group_st in sample_table.groupby(groupby):
-        group_ds = ds.loc[dict(sample_id=list(group_st["sample_id"].values))]
-        yield group, group_ds
+
+    # sample_table = ds.sample_table.to_pandas()
+    # for group, group_st in sample_table.groupby(groupby):
+    #    group_ds = ds.loc[dict(sample_id=list(group_st["sample_id"].values))]
+    #    yield group, group_ds
+
+    return iter_groups(*args, "sample")
 
 
-def iter_peptide_groups(ds, groupby):
-    """
+def iter_peptide_groups(*args):
+
+    """DEPRECATED - use 'iter_groups()' instead
+
     returns an iterator yeilding subsets of the provided dataset,
-    grouped by an item on the peptide metadata coodinate.
-    """
-    peptide_table = ds.peptide_table.to_pandas()
-    for group, group_st in peptide_table.groupby(groupby):
-        group_ds = ds.loc[dict(peptide_id=list(group_st.index.values))]
-        yield group, group_ds
+    grouped by an item on the peptide metadata coodinate. """
+
+    # peptide_table = ds.peptide_table.to_pandas()
+    # for group, group_st in peptide_table.groupby(groupby):
+    #    group_ds = ds.loc[dict(peptide_id=list(group_st.index.values))]
+    #    yield group, group_ds
+
+    return iter_groups(*args, "peptide")
 
 
-# This could be generalized to do some helpful things with the enirchment tables
+# TODO dim not table parameter to be consistant
 def id_coordinate_subset(
     ds,
     where,

--- a/test/sim_test_generator.py
+++ b/test/sim_test_generator.py
@@ -107,77 +107,63 @@ def make_hardcoded_ds():
     8            5   6   5   9   5   7   4   0   6   9   8   0
     9            1   6   2   0   0   0   2   2   6   2   8   9
 
-    SAMPLE ANNOTATIONS
 
-    sample_metadata u_id tech_rep_id bio_rep_id   fastq_filename reference seq_dir
+    SAMPLE ANNOTATIONS
+    sample_metadata participant_id sequencing_run   fastq_filename time_point
     sample_id
-    0                  0           0          0   sample_0.fastq      refa    expa
-    1                  1           0          0   sample_1.fastq      refa    expa
-    2                  2           1          0   sample_2.fastq      refa    expa
-    3                  3           1          0   sample_3.fastq      refa    expa
-    4                  4           2          1   sample_4.fastq      refa    expa
-    5                  5           2          1   sample_5.fastq      refa    expa
-    6                  6           3          1   sample_6.fastq      refa    expa
-    7                  7           3          1   sample_7.fastq      refa    expa
-    8                  8           4          2   sample_8.fastq      refa    expa
-    9                  9           4          2   sample_9.fastq      refa    expa
-    10                10           5          2  sample_10.fastq      refa    expa
-    11                11           5          2  sample_11.fastq      refa    expa
+    0                            0              0   sample_0.fastq          0
+    1                            0              0   sample_1.fastq          1
+    2                            0              1   sample_2.fastq          0
+    3                            0              1   sample_3.fastq          1
+    4                            1              0   sample_4.fastq          0
+    5                            1              0   sample_5.fastq          1
+    6                            1              1   sample_6.fastq          0
+    7                            1              1   sample_7.fastq          1
+    8                            2              0   sample_8.fastq          0
+    9                            2              0   sample_9.fastq          1
+    10                           2              1  sample_10.fastq          0
+    11                           2              1  sample_11.fastq          1
+
 
     PEPTIDE ANNOTATIONS
 
-    peptide_metadata Oligo  is_wt
+    peptide_metadata oligo  is_wt loc
     peptide_id
-    0                 ATCG  False
-    1                 ATCG   True
-    2                 ATCG   True
-    3                 ATCG   True
-    4                 ATCG   True
-    5                 ATCG  False
-    6                 ATCG   True
-    7                 ATCG   True
-    8                 ATCG   True
-    9                 ATCG   True
+    0                 ATCG   True   0
+    1                 ATCG  False   0
+    2                 ATCG  False   0
+    3                 ATCG  False   0
+    4                 ATCG  False   0
+    5                 ATCG   True   1
+    6                 ATCG  False   1
+    7                 ATCG  False   1
+    8                 ATCG  False   1
+    9                 ATCG  False   1
 
     """
 
     # TODO test a non-collapse
-    fastq_filename = [f"sample_{i}.fastq" for i in range(12)]
-    reference = [f"refa" for _ in range(12)]
-    seq_dir = [f"expa" for _ in range(12)]
-    bio_reps = [i for i in range(3) for _ in range(4)]
-    tech_reps = [i for i in range(6) for _ in range(2)]
+    # TODO Add controls?
+    # TODO library batch example?
 
-    columns = [
-        "sample_id",
-        "u_id",
-        "tech_rep_id",
-        "bio_rep_id",
-        "fastq_filename",
-        "reference",
-        "seq_dir",
-    ]
-    df = pd.DataFrame(
-        zip(
-            range(len(reference)),
-            range(len(reference)),
-            tech_reps,
-            bio_reps,
-            fastq_filename,
-            reference,
-            seq_dir,
-        ),
-        columns=columns,
-    )
-    sample_metadata = df.set_index("sample_id")
+    sample_metadata = pd.DataFrame(
+        {
+            "sample_id": range(12),
+            "participant_id": [i for i in range(3) for _ in range(4)],
+            "sequencing_run": [i for _ in range(3) for i in range(2) for _ in range(2)],
+            "fastq_filename": [f"sample_{i}.fastq" for i in range(12)],
+            "time_point": [i for _ in range(6) for i in range(2)],
+        }
+    ).set_index("sample_id")
 
-    columns = ["peptide_id", "Oligo", "is_wt"]
-    oligos = ["ATCG" for _ in range(10)]
-    is_wt = [True] * 10
-    is_wt[0] = False
-    is_wt[5] = False
-    df = pd.DataFrame(zip(range(10), oligos, is_wt), columns=columns)
-    peptide_metadata = df.set_index("peptide_id")
+    peptide_metadata = pd.DataFrame(
+        {
+            "peptide_id": range(10),
+            "oligo": ["ATCG" for _ in range(10)],
+            "is_wt": (["True"] + ["False"] * 4) * 2,
+            "loc": [i for i in range(2) for _ in range(5)],
+        }
+    ).set_index("peptide_id")
 
     np.random.seed(23)
     counts = np.random.randint(0, 10, [10, 12])

--- a/test/sim_test_generator.py
+++ b/test/sim_test_generator.py
@@ -84,3 +84,108 @@ def generate_sim_ds(
 
     counts_df = pd.DataFrame(counts)
     return stitch_dataset(counts_df, peptide_metadata, sample_metadata)
+
+
+def make_hardcoded_ds():
+
+    """
+    A hard coded annotation dataset for testing all sorts of
+    functions
+
+    COUNTS
+
+    sample_id   0   1   2   3   4   5   6   7   8   9   10  11
+    peptide_id
+    0            3   6   8   9   6   8   7   9   3   6   1   2
+    1            5   5   0   5   0   9   9   3   1   7   4   1
+    2            1   4   6   7   3   6   9   2   3   0   8   6
+    3            6   0   5   6   0   2   0   3   0   6   2   2
+    4            5   7   9   4   7   7   3   5   5   6   4   6
+    5            8   5   0   4   1   9   4   5   9   8   7   1
+    6            0   5   3   7   6   4   0   2   5   1   8   2
+    7            4   0   4   3   4   0   6   8   6   1   9   9
+    8            5   6   5   9   5   7   4   0   6   9   8   0
+    9            1   6   2   0   0   0   2   2   6   2   8   9
+
+    SAMPLE ANNOTATIONS
+
+    sample_metadata u_id tech_rep_id bio_rep_id   fastq_filename reference seq_dir
+    sample_id
+    0                  0           0          0   sample_0.fastq      refa    expa
+    1                  1           0          0   sample_1.fastq      refa    expa
+    2                  2           1          0   sample_2.fastq      refa    expa
+    3                  3           1          0   sample_3.fastq      refa    expa
+    4                  4           2          1   sample_4.fastq      refa    expa
+    5                  5           2          1   sample_5.fastq      refa    expa
+    6                  6           3          1   sample_6.fastq      refa    expa
+    7                  7           3          1   sample_7.fastq      refa    expa
+    8                  8           4          2   sample_8.fastq      refa    expa
+    9                  9           4          2   sample_9.fastq      refa    expa
+    10                10           5          2  sample_10.fastq      refa    expa
+    11                11           5          2  sample_11.fastq      refa    expa
+
+    PEPTIDE ANNOTATIONS
+
+    peptide_metadata Oligo  is_wt
+    peptide_id
+    0                 ATCG  False
+    1                 ATCG   True
+    2                 ATCG   True
+    3                 ATCG   True
+    4                 ATCG   True
+    5                 ATCG  False
+    6                 ATCG   True
+    7                 ATCG   True
+    8                 ATCG   True
+    9                 ATCG   True
+
+    """
+
+    # TODO test a non-collapse
+    fastq_filename = [f"sample_{i}.fastq" for i in range(12)]
+    reference = [f"refa" for _ in range(12)]
+    seq_dir = [f"expa" for _ in range(12)]
+    bio_reps = [i for i in range(3) for _ in range(4)]
+    tech_reps = [i for i in range(6) for _ in range(2)]
+
+    columns = [
+        "sample_id",
+        "u_id",
+        "tech_rep_id",
+        "bio_rep_id",
+        "fastq_filename",
+        "reference",
+        "seq_dir",
+    ]
+    df = pd.DataFrame(
+        zip(
+            range(len(reference)),
+            range(len(reference)),
+            tech_reps,
+            bio_reps,
+            fastq_filename,
+            reference,
+            seq_dir,
+        ),
+        columns=columns,
+    )
+    sample_metadata = df.set_index("sample_id")
+
+    columns = ["peptide_id", "Oligo", "is_wt"]
+    oligos = ["ATCG" for _ in range(10)]
+    is_wt = [True] * 10
+    is_wt[0] = False
+    is_wt[5] = False
+    df = pd.DataFrame(zip(range(10), oligos, is_wt), columns=columns)
+    peptide_metadata = df.set_index("peptide_id")
+
+    np.random.seed(23)
+    counts = np.random.randint(0, 10, [10, 12])
+
+    ds = generate_sim_ds(
+        counts=counts,
+        sample_metadata=sample_metadata,
+        peptide_metadata=peptide_metadata,
+    )
+
+    return ds

--- a/test/test_collapse.py
+++ b/test/test_collapse.py
@@ -23,7 +23,8 @@ from sim_test_generator import generate_sim_ds
 
 # functions I'll be testing here
 from phippery.collapse import collapse_sample_groups
-from phippery.collapse import pairwise_correlation_by_sample_group
+
+# from phippery.collapse import pairwise_correlation_by_sample_group
 from phippery.normalize import cpm
 
 
@@ -62,9 +63,7 @@ def test_collapse_sample_groups():
     ds = generate_sim_ds(counts=counts, sample_metadata=sample_metadata)
     cpm(ds, per_sample=True, inplace=True)
 
-    mean_tech_rep_ds = collapse_sample_groups(
-        ds, group="tech_rep_id", compute_pw_cc=True
-    )
+    mean_tech_rep_ds = collapse_sample_groups(ds, ["tech_rep_id"], compute_pw_cc=True)
 
     # FIXME This should do it -> other than the datatype issue of counts
     # mean_tech_rep_ds = collapse_sample_groups(
@@ -101,6 +100,6 @@ def test_collapse_sample_groups():
         assert np.allclose(cc_sol, local_cc_sol)
 
 
-def test_pairwise_correlation_by_sample_group():
-    # TODO
-    pass
+# def test_pairwise_correlation_by_sample_group():
+#    # TODO
+#    pass

--- a/test/test_collapse.py
+++ b/test/test_collapse.py
@@ -20,86 +20,55 @@ import glob
 
 # local
 from sim_test_generator import generate_sim_ds
+from sim_test_generator import make_hardcoded_ds
 
 # functions I'll be testing here
-from phippery.collapse import collapse_sample_groups
+from phippery.collapse import collapse_groups
 
 # from phippery.collapse import pairwise_correlation_by_sample_group
 from phippery.normalize import cpm
 
-
-def test_collapse_sample_groups():
-
-    # TODO test a non-collapse
-    fastq_filename = [f"sample_{i}.fastq" for i in range(12)]
-    reference = [f"refa" for _ in range(12)]
-    seq_dir = [f"expa" for _ in range(12)]
-    bio_reps = [i for i in range(3) for _ in range(4)]
-    tech_reps = [i for i in range(6) for _ in range(2)]
-
-    columns = [
-        "sample_id",
-        "u_id",
-        "tech_rep_id",
-        "bio_rep_id",
-        "fastq_filename",
-        "reference",
-        "seq_dir",
-    ]
-    df = pd.DataFrame(
-        zip(
-            range(len(reference)),
-            range(len(reference)),
-            tech_reps,
-            bio_reps,
-            fastq_filename,
-            reference,
-            seq_dir,
-        ),
-        columns=columns,
-    )
-    sample_metadata = df.set_index("sample_id")
-    counts = np.random.randint(0, 10, [10, 12])
-    ds = generate_sim_ds(counts=counts, sample_metadata=sample_metadata)
-    cpm(ds, per_sample=True, inplace=True)
-
-    mean_tech_rep_ds = collapse_sample_groups(ds, ["tech_rep_id"], compute_pw_cc=True)
-
-    # FIXME This should do it -> other than the datatype issue of counts
-    # mean_tech_rep_ds = collapse_sample_groups(
-    #    ds, group="u_id", compute_pw_cc=True
-    # )
-
-    assert "tech_rep_id_cpm_pw_cc" in mean_tech_rep_ds.sample_metadata.values
-    assert "tech_rep_id_cpm_n_reps" in mean_tech_rep_ds.sample_metadata.values
-    assert "tech_rep_id_counts_pw_cc" in mean_tech_rep_ds.sample_metadata.values
-    assert "tech_rep_id_counts_n_reps" in mean_tech_rep_ds.sample_metadata.values
-
-    cpm_ex = ds["cpm"].values
-    comb = [(i, i + 1) for i in range(0, 12, 2)]
-
-    for m in ["counts", "cpm"]:
-
-        enr = counts if m == "counts" else cpm_ex
-
-        mean_sol = np.zeros([10, 6])
-        for t, (i, j) in enumerate(comb):
-            mean_sol[:, t] = np.mean(enr[:, [i, j]], axis=1)
-        local_mean_sol = mean_tech_rep_ds[m].values
-
-        # compare our solution to a more interpretable solution
-        assert np.allclose(mean_sol, local_mean_sol)
-
-        enr_corr = pd.DataFrame(enr).corr()
-        cc_sol = np.array([round(enr_corr.iloc[i, j], 5) for (i, j) in comb])
-        local_cc_sol = mean_tech_rep_ds.sample_table.loc[
-            :, f"tech_rep_id_{m}_pw_cc"
-        ].values.astype(np.float64)
-
-        # compare our solution to pandas corr computed manually
-        assert np.allclose(cc_sol, local_cc_sol)
+from phippery.phipdata import stitch_dataset
 
 
-# def test_pairwise_correlation_by_sample_group():
-#    # TODO
-#    pass
+def test_throw_mm_features():
+    pass
+
+
+def test_first():
+    pass
+
+
+def test_mean_pw_cc():
+    pass
+
+
+def test_mean_pw_cc_mt():
+    pass
+
+
+def test_collapse_peptides():
+
+    ds = make_hardcoded_ds()
+    dsb = collapse_groups(ds, by=["is_wt"], collapse_dim="peptide")
+
+    counts = ds.counts.values
+    new = np.zeros([2, 12])
+    new[0, :] = counts[[0, 5], :].mean(axis=0)
+    new[1, :] = counts[[1, 2, 3, 4, 6, 7, 8, 9], :].mean(axis=0)
+
+    assert np.all(dsb.counts.values == new)
+
+
+def test_collapse_samples():
+
+    ds = make_hardcoded_ds()
+    dsb = collapse_groups(ds, by=["bio_rep_id"], collapse_dim="sample")
+
+    counts = ds.counts.values
+    new = np.zeros([10, 3])
+    new[:, 0] = counts[:, 0:4].mean(axis=1)
+    new[:, 1] = counts[:, 4:8].mean(axis=1)
+    new[:, 2] = counts[:, 8:12].mean(axis=1)
+
+    assert np.all(dsb.counts.values == new)

--- a/test/test_collapse.py
+++ b/test/test_collapse.py
@@ -35,35 +35,27 @@ def test_throw_mm_features():
     pass
 
 
-def test_first():
-    pass
-
-
 def test_mean_pw_cc():
     pass
 
 
-def test_mean_pw_cc_mt():
-    pass
-
-
-def test_collapse_peptides():
+def test_simgle_anno_collapse_peptides():
 
     ds = make_hardcoded_ds()
     dsb = collapse_groups(ds, by=["is_wt"], collapse_dim="peptide")
 
     counts = ds.counts.values
     new = np.zeros([2, 12])
-    new[0, :] = counts[[0, 5], :].mean(axis=0)
-    new[1, :] = counts[[1, 2, 3, 4, 6, 7, 8, 9], :].mean(axis=0)
+    new[1, :] = counts[[0, 5], :].mean(axis=0)
+    new[0, :] = counts[[1, 2, 3, 4, 6, 7, 8, 9], :].mean(axis=0)
 
     assert np.all(dsb.counts.values == new)
 
 
-def test_collapse_samples():
+def test_single_anno_collapse_samples():
 
     ds = make_hardcoded_ds()
-    dsb = collapse_groups(ds, by=["bio_rep_id"], collapse_dim="sample")
+    dsb = collapse_groups(ds, by=["participant_id"], collapse_dim="sample")
 
     counts = ds.counts.values
     new = np.zeros([10, 3])

--- a/test/test_collapse.py
+++ b/test/test_collapse.py
@@ -24,18 +24,31 @@ from sim_test_generator import make_hardcoded_ds
 
 # functions I'll be testing here
 from phippery.collapse import collapse_groups
+from phippery.collapse import mean_pw_cc_by
 
 # from phippery.collapse import pairwise_correlation_by_sample_group
 from phippery.normalize import cpm
 
 from phippery.phipdata import stitch_dataset
 
+# TODO more edge cases
+# More error handle testing.
 
+
+# TODO
 def test_throw_mm_features():
     pass
 
 
-def test_mean_pw_cc():
+def test_mean_pw_cc_peptide_runs():
+    ds = make_hardcoded_ds()
+    mean_pw_cc_by(ds, by="is_wt", dim="peptide")
+    pass
+
+
+def test_mean_pw_cc_sample_runs():
+    ds = make_hardcoded_ds()
+    mean_pw_cc_by(ds, by="participant_id")
     pass
 
 


### PR DESCRIPTION
This PR generalizes the [collapse_sample_groups](https://github.com/matsengrp/phippery/blob/c68cedf3380263d2cbc99523cb71d3a990645e54/phippery/collapse.py#L25)
to the more sophisticated [collapse_groups](https://github.com/matsengrp/phippery/blob/41866d78eefae38ca419ac6261999db7801a28d4/phippery/collapse.py#L49)
here, we can:

1. Collapse both sample and peptide annotations/dimensions

2. use any function to collapse on that turns 2D array of size _MxN_ -> 1D array of size M or N depending on the dimension being collapsed on

3. collapse on a list of annotation features `by=["X", "Y"]"

4. documentation and a much cleaner/more modular. 