### PR TITLE
Adding outlier protection

### DIFF
--- a/phippery/modeling.py
+++ b/phippery/modeling.py
@@ -77,7 +77,8 @@ def neg_binom_model(
     ds,
     beads_ds,
     nb_p=2,
-    trim_percentile=99.9,
+    trim_percentile=100.,
+    outlier_reject_scale=10.,
     data_table="size_factors",
     inplace=True,
     new_table_name="neg_binom_mlxp",
@@ -112,7 +113,9 @@ def neg_binom_model(
     nb_size = []
     nb_prob = []
     for i in range(beads_counts.shape[0]):
-        (mu, alpha, var, size, prob) = fit_neg_binom(trimmed_data[i].compressed(), nb_p)
+        (mu, alpha, var, size, prob) = fit_neg_binom(
+            trimmed_data[i].compressed(), nb_p, outlier_reject_scale
+        )
         nb_mu.append(mu)
         nb_alpha.append(alpha)
         nb_var.append(var)

--- a/phippery/negbinom.py
+++ b/phippery/negbinom.py
@@ -38,12 +38,22 @@ def nb_mlxp(counts, size, prob):
     return mlxp
 
 
-def fit_neg_binom(x, p):
+def fit_neg_binom(x, p, outlier_reject_scale=10):
     """Fit a Type-I (p=1) or Type-II (p=2) negative binominal to each peptide across all samples
     Uses the "mu, alpha" parametrization in statsmodels
     If x is empty, all returned values are -1
     If the fit fails to converge, all returned values are -2
+    Data lying [outlier_reject_scale]*[interquartile range] beyond the 75th percentile
+    are dropped from the fit to improve fit convergence.
     """
+
+    # Remove extreme outliers, which are data points that lie beyond
+    # 10 times the interquartile range above the 75th percentile
+    q75, q25 = np.percentile(x, [75, 25])
+    iqr = q75 - q25
+    if iqr > 1:
+        outlier_cut = q75 + outlier_reject_scale*iqr
+        x = np.array([xi for xi in x if xi < outlier_cut])
 
     mu    = -1
     alpha = -1


### PR DESCRIPTION
This patch implements the rejection of extreme outliers to improve fit convergence. The outlier cutoff is based on a multiple of the interquartile range of the data. This multiplicative factor (default is 10) can be customized at the top level neg_binom_model() function.