### PR TITLE
Autobuild and push releases to PyPI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.7]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/docs_pages_workflow.yml
+++ b/.github/workflows/docs_pages_workflow.yml
@@ -17,9 +17,9 @@ jobs:
  
     steps:
 
-        #    - uses: actions/checkout@v2
+        #    - uses: actions/checkout@v3
         #    - name: Set up Python ${{ matrix.python-version }}
-        #      uses: actions/setup-python@v2
+        #      uses: actions/setup-python@v4
         #      with:
         #        python-version: ${{ matrix.python-version }}
         #    - name: Install dependencies

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Build python package
         run: |
+          python -m pip install build
           python -m build --wheel
 
       - name: Publish package

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,45 @@
+name: Build Python package
+
+on:
+  release:
+    types:
+      - published
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: Install phippery
+        run: |
+            pip install -e ".[dev]"
+      - name: Test
+        run: |
+          pytest
+
+      - name: Build python package
+        run: |
+          python -m build --wheel
+
+      - name: Publish package
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -18,9 +18,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/phippery/__init__.py
+++ b/phippery/__init__.py
@@ -1,6 +1,6 @@
 # __init__.py
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from phippery.utils import *
 from phippery.normalize import *

--- a/phippery/cli.py
+++ b/phippery/cli.py
@@ -438,4 +438,4 @@ def to_wide_csv(filename, output_prefix):
         click.echo(e)
         return
 
-    phippery.utils.to_wide_csv(ds, output_prefix)
+    to_wide_csv(ds, output_prefix)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phippery"
-version = "1.1.0"
+version = "1.1.1"
 description = "Tools for analyzing PhIP-Seq Data."
 readme = "README.md"
 authors = [
@@ -60,7 +60,7 @@ phippery = "phippery.cli:cli"
 
 
 [tool.bumpver]
-current_version = "1.1.0"
+current_version = "1.1.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
@jgallowa07, in case you're interested in automating the process of pushing new releases of phippery to PyPI, I think that this GH Action should do the trick. You'll have to add your PyPI API Key as a GH Secret called `PYPI_API_TOKEN` for it to work. I haven't completely tested this, but I am hoping it might make your life easier.