### PR TITLE
Add back missing peptides with reindex()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 *.pyc
+build/
+phippery.egg-info/


### PR DESCRIPTION
I made this because Pritha came across a bug which I think was causing a problem because some of the peptides from the library hadn't been sequenced across any of the samples. Does this look like a reasonable modification of your code for merging the data?