### PR TITLE
size factors deprecation warning in docstring

### DIFF
--- a/phippery/normalize.py
+++ b/phippery/normalize.py
@@ -713,6 +713,11 @@ def _comp_diff_sel(base, all_other_values, scalar=1):
 
 def size_factors(ds, inplace=True, data_table="counts", new_table_name="size_factors"):
     r"""
+    Warning
+    -------
+    This method is deprecated. It is currently maintained only for reproducibility of previous results.
+   
+
     Compute size factors from 
     `Anders and Huber 2010 
     <https://genomebiology.biomedcentral.com/articles/10.1186/gb-2010-11-10-r106>`_.


### PR DESCRIPTION
@jgallowa07 
I've added a deprecation warning to the docstring in `normalize.size_factors()` function. Not sure if you would want to add a warning printout in the function, but I doubt anyone would accidentally call this without seeing it on the web docs.