### PR TITLE
Resolve z-score discrepancy due to beads samples ordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/hdc-workflows/ubuntu:20.04
 ADD http://date.jsontest.com /etc/builddate
 
 LABEL maintainer "Jared Galloway <jgallowa@fredhutch.rg>" \
-      version "1.2.0" \
+      version "1.3.0" \
       description "Common PhIP-Seq Workflows"
 
 # install needed tools
@@ -30,17 +30,17 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # install phippery
-RUN pip install git+https://github.com/matsengrp/phippery@1.2.0
+RUN pip install git+https://github.com/matsengrp/phippery@1.3.0
 
 # install pre-build binary Bowtie1.3
-RUN curl -fksSL https://sourceforge.net/projects/bowtie-bio/files/bowtie/1.3.1/bowtie-1.3.1-linux-x86_64.zip \
-    --output bowtie-1.3.1-linux-x86_64.zip \
-    && unzip bowtie-1.3.1-linux-x86_64.zip \
-    && (cd /usr/bin/ && ln -s /bowtie-1.3.1-linux-x86_64/* ./)
+RUN curl -fksSL https://sourceforge.net/projects/bowtie-bio/files/bowtie/1.3.0/bowtie-1.3.1-linux-x86_64.zip \
+    --output bowtie-1.3.0-linux-x86_64.zip \
+    && unzip bowtie-1.3.0-linux-x86_64.zip \
+    && (cd /usr/bin/ && ln -s /bowtie-1.3.0-linux-x86_64/* ./)
 
 
 # install SAMtools
-RUN curl -fksSL https://github.com/samtools/samtools/releases/download/1.3.1/samtools-1.3.1.tar.bz2 | tar xj && \
-    cd samtools-1.3.1 && \
+RUN curl -fksSL https://github.com/samtools/samtools/releases/download/1.3.0/samtools-1.3.1.tar.bz2 | tar xj && \
+    cd samtools-1.3.0 && \
     make all all-htslib && make install install-htslib
 

--- a/phippery/__init__.py
+++ b/phippery/__init__.py
@@ -1,7 +1,7 @@
 # __init__.py
 
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 from phippery.utils import *
 import phippery.normalize

--- a/phippery/zscore.py
+++ b/phippery/zscore.py
@@ -6,6 +6,7 @@
 
 import numpy as np
 import pandas as pd
+import math
 from functools import reduce
 
 
@@ -20,7 +21,7 @@ def zscore_pids_binning(
     # For each peptide, sum the 'data_table' quantity across beads-only samples
     # Initially, all 'peptide_id's with the same sum are binned together
     sums_df = pd.DataFrame(index=beads_ds.peptide_id.values, columns=["sum"])
-    sums_df["sum"] = np.sum(beads_data, axis=1)
+    sums_df["sum"] = [math.fsum(data) for data in beads_data]
     sums_df = sums_df.sort_values("sum")
     uniq_sum_values = sums_df["sum"].drop_duplicates().values
 

--- a/phippery/zscore.py
+++ b/phippery/zscore.py
@@ -120,9 +120,9 @@ def compute_zscore(
             null_means = means_df.loc[ibin].to_numpy()
             null_stds = stds_df.loc[ibin].to_numpy()
             # TODO This line throws warnings about invalid values, and divide by zero
-            # Compute zs, avoiding division by zero
-            # zs = np.where(null_stds != 0, (data - null_means) / null_stds, 0)
-            zs = (data - null_means) / null_stds
+            # Compute zs, avoiding division by zero? for now, catch annoying warning
+            with np.errstate(divide="ignore", invalid="ignore"):
+                zs = (data - null_means) / null_stds
         zscore_df.loc[pid] = zs
 
     # Convert Infs and NaNs to zero

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "phippery"
 
-version = "1.2.0"
+version = "1.3.0"
 
 description = "Tools for analyzing PhIP-Seq Data."
 readme = "README.md"
@@ -63,7 +63,7 @@ phippery = "phippery.cli:cli"
 
 [tool.bumpver]
 
-current_version = "1.2.0"
+current_version = "1.3.0"
 
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"


### PR DESCRIPTION
Use [math.fsum](https://docs.python.org/3/library/math.html#math.fsum) to minimize rounding errors when summing CPMs over beads samples to determine peptide binning before computing Z-scores. Rounding errors can cause binning differences depending on the input order of beads samples, leading to different Z-score results.

I've made an example that demonstrates discrepant Z-scores if ran without the patch in this PR:
`/fh/fast/matsen_e/ksung2/phippery_test_data/zscore_test.py`
This is tested with V1.13 VS57_Vir3_Jan2023_Z7 virscan.phip file.