### PR TITLE
Fix README badges: finish master→main migration and revive CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/docs_pages_workflow.yml
+++ b/.github/workflows/docs_pages_workflow.yml
@@ -1,6 +1,6 @@
 name: docs_pages_workflow
  
-# execute this workflow automatically when a we push to master
+# execute this workflow automatically when we push to main
 on:
   push:
     branches: [ main ]
@@ -9,11 +9,11 @@ jobs:
  
   build_docs_job:
     runs-on: ubuntu-latest
-    # container: debian:buster-slim
-    container: debian:buster
+    # container: debian:bookworm-slim
+    container: debian:bookworm
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ["3.12"]
  
     steps:
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -18,11 +18,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Docker Repository on Quay](https://quay.io/repository/hdc-workflows/phippery/status "Docker Repository on Quay")](https://quay.io/repository/hdc-workflows/phippery)
-[![build and test](https://github.com/matsengrp/phippery/workflows/build%20and%20test/badge.svg)](https://github.com/matsengrp/phippery/blob/master/.github/workflows/build-and-test.yaml)
+[![build and test](https://github.com/matsengrp/phippery/actions/workflows/build-and-test.yaml/badge.svg?branch=main)](https://github.com/matsengrp/phippery/actions/workflows/build-and-test.yaml)
+[![docs](https://github.com/matsengrp/phippery/actions/workflows/docs_pages_workflow.yml/badge.svg?branch=main)](https://github.com/matsengrp/phippery/actions/workflows/docs_pages_workflow.yml)
+[![package](https://github.com/matsengrp/phippery/actions/workflows/package.yaml/badge.svg?branch=main)](https://github.com/matsengrp/phippery/actions/workflows/package.yaml)
 
 A set of functions designed to query an 
 [xarray DataSet](http://xarray.pydata.org/en/stable/user-guide/data-structures.html#dataset) 
@@ -29,3 +31,22 @@ git clone https://github.com/matsengrp/phippery.git
 (cd phippery && pip install -e ".[dev]")
 ```
 
+## Container image (Quay)
+
+The Quay badge above reflects **Quay.io's own build status**, not GitHub
+Actions. It is currently stuck on `building`: the last two automated
+builds `expired` (timed out), and the image tags (`main`, `latest`) were
+last successfully pushed in Nov 2024.
+
+Fixing this requires **Quay admin access on the `hdc-workflows` org** (it
+cannot be changed from this repo). Maintainer checklist:
+
+1. Check the build trigger's **timeout** setting — `expired` means the
+   build exceeded Quay's time limit. The `Dockerfile`'s
+   `ADD http://date.jsontest.com ...` cache-bust plus `apt-get`/`pip`
+   steps may be slow.
+2. Verify the **robot account** still has push permissions and the GitHub
+   build trigger is still connected/authorized.
+3. Confirm the **build context / Dockerfile path** in the trigger matches
+   the repo (the `Dockerfile` is at the repo root).
+4. Trigger a **manual build** and watch the logs for the actual failure.

--- a/phippery/modeling.py
+++ b/phippery/modeling.py
@@ -187,7 +187,10 @@ def zscore(
 
     binning = zscore_pids_binning(beads_ds, data_table, min_Npeptides_per_bin)
 
-    zscore_table = copy.deepcopy(ds[f"{data_table}"].to_pandas())
+    # Cast to float: the source layer may be integer-typed, and pandas 3.0 no
+    # longer silently upcasts on the `.loc` assignment below (it raises on a
+    # lossy set). Z-scores are float-valued, so float is the correct dtype.
+    zscore_table = copy.deepcopy(ds[f"{data_table}"].to_pandas()).astype(float)
     zs_df, mu_df, sigma_df = compute_zscore(
         ds, data_table, binning, lower_quantile_limit, upper_quantile_limit
     )

--- a/phippery/zscore.py
+++ b/phippery/zscore.py
@@ -109,7 +109,13 @@ def compute_zscore(
         for pid in binning[i]:
             pid_to_bin_df.loc[pid] = i
 
-    zscore_df = pd.DataFrame(index=data_df.index, columns=data_df.columns)
+    # Explicitly float-typed: z-scores are float-valued, and pandas 3.0 no
+    # longer silently upcasts an object-dtype frame when these values are
+    # assigned downstream (it raises on a lossy set). An empty DataFrame with
+    # no dtype defaults to object under pandas 3.0, so declare float here.
+    zscore_df = pd.DataFrame(
+        index=data_df.index, columns=data_df.columns, dtype=float
+    )
     for pid in zscore_df.index:
         ibin = pid_to_bin_df.loc[pid]["ibin"]
         if ibin < 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dev = [
     "setuptools>=58.0",
     "packaging>=21.0",
     "pytest",
-    "pytest-pep8",
     "pytest-datadir",
     "pre-commit",
     "black",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "POT",
     "biopython"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Closes #198

## Summary

Finishes the unfinished `master`→`main` default-branch migration and modernizes CI off end-of-life Python runtimes, so the README badges reflect real, passing runs on `main`.

**What changed (5 commits, all config/docs — no application logic):**

| File | Change |
|------|--------|
| `.github/workflows/build-and-test.yaml` | matrix `[3.7, 3.8, 3.9]` → `["3.9", "3.10", "3.11", "3.12"]`; `checkout@v3`→`@v4`, `setup-python@v4`→`@v5` |
| `.github/workflows/package.yaml` | removed dangling `${{ matrix.python-version }}` (no matrix was ever defined) → pinned `"3.12"`; same action bumps |
| `.github/workflows/docs_pages_workflow.yml` | `debian:buster` (EOL) → `debian:bookworm`; `[3.7]` pin → `["3.12"]`; fixed stale "push to master" comment → "to main" |
| `pyproject.toml` | `requires-python = ">=3.7"` → `">=3.9"` (matches the new matrix floor) |
| `README.md` | legacy `build and test` badge → modern `actions/workflows/<file>.yaml/badge.svg?branch=main` form; **added** docs + package badges; **added** "Container image (Quay)" maintainer-checklist subsection |

**Acceptance criteria met (verified against the branch diff):**
- ✅ README badges use the modern `?branch=main` form; no `/master` refs remain in README.
- ✅ Three workflow badges present with correct basenames (incl. the `.yml` vs `.yaml` distinction).
- ✅ `grep -rnE "3\.7|debian:buster" .github/workflows/` returns nothing.
- ✅ `package.yaml` no longer references a phantom matrix.
- ✅ `requires-python = ">=3.9"`; matrix floor and `requires-python` agree at 3.9.
- ✅ README documents the Quay container-badge situation + maintainer checklist.

## Deviations from spec

- **`package.yaml` matrix fix — chose the smaller diff.** The spec allowed either (a) adding a single-entry `strategy.matrix` or (b) replacing the dangling `${{ matrix.python-version }}` with a concrete version string, implementer's choice. This PR took (b): pinned `"3.12"` directly. This job builds+publishes one wheel; it does not need a test matrix, so the concrete pin is the clearer, smaller change.
- **Docs-workflow matrix pin is currently decorative (noted, not fixed).** In `docs_pages_workflow.yml`, `python-version: ["3.12"]` is not consumed by any live step — the `setup-python` block that would read it is commented out, so the actual interpreter is `debian:bookworm`'s system `python3` (3.11, installed via `apt-get`). Bumping the pin to `["3.12"]` satisfies the spec's literal ask and removes the `3.7` EOL reference; bookworm's 3.11 still honors `requires-python >=3.9`, so there is no runtime conflict. This is a **pre-existing** cosmetic inconsistency (the `[3.7]` pin was equally decorative), not a regression introduced here. A future cleanup could either drop the unused matrix or re-enable `setup-python` — left out of scope for this badge-focused change.

## Not in this diff (by design — see #198 workstreams 3 & 4)

- **Deleting remote `master`** (`git push origin --delete master`) is a land-time remote op, not a commit. Its one unique commit `b16c0af` is an already-merged PR #118 rename artifact — no work is lost. **To be done at land time.**
- **Post-merge CI-fire verification** (`gh run list` / `total_count > 0`) can only run after this merges to `main`. This is the real proof the badges go green — the issue was triggered by *zero* historical workflow runs, so watch the Actions tab after merge. If workflows still don't fire, that points to a repo/org Actions **setting** and warrants a follow-up escalation issue.
- **The Quay badge** will still render `building`/stale after this merges — only its *documentation* is in scope here. The actual fix needs Quay admin on `hdc-workflows` (the maintainer already re-enabled the `main` push trigger; the README checklist covers the rest).

---

## Update: CI revived and surfaced two dormant dep-rot bugs (both fixed here)

Pushing this branch fired GitHub Actions for the **first time in the repo's history** (`total_count` 0 → 2) — proving the migration fix works. The initial runs failed, surfacing two long-hidden bugs that were invisible while CI was dead. Both are now fixed and the suite is green (27 passed) on CI's Python 3.11 with the modern pytest/pandas stack:

1. **`pytest-pep8` (abandoned 2014) crashed collection.** It declares the legacy `pytest_collect_file(path, parent)` hook signature that modern pytest (≥7) rejects with `PluginValidationError` — pytest never reached a single test. Removed it (style is already enforced by `black` + `pre-commit`).
2. **pandas 3.0 broke the z-score path.** `compute_zscore()` built its result frame with no explicit dtype (object under pandas 3.0); assigning it into the enrichment table raised a lossy-set `TypeError` because pandas 3.0 dropped silent `object`→`float64` upcasting. Declared the z-score frame `dtype=float` at construction and cast the destination table to float. Fixes `test_cpm_zscore`.

Verified locally on `python3.11` (CI's exact 3.11.15 build) with pytest 9.1.1 / pandas 3.0.3: **27 passed, 0 failed.**

## Additional deviations from spec

- The spec anticipated CI *might* fail once revived and treated that as an escalation path. In practice the failures were two fixable dep-rot bugs, not an Actions-settings problem — so they are fixed in-branch (per maintainer direction) rather than deferred. This keeps "revive CI" honest end-to-end: the badges go green, not merely non-blank.
