### PR TITLE
Fix docs_pages_workflow PEP 668 failure + gate it on PRs

### DIFF
--- a/.github/workflows/docs_pages_workflow.yml
+++ b/.github/workflows/docs_pages_workflow.yml
@@ -1,8 +1,11 @@
 name: docs_pages_workflow
  
-# execute this workflow automatically when we push to main
+# execute this workflow automatically when we push to main, and on PRs to
+# main so a broken docs build gates the PR instead of only failing after merge
 on:
   push:
+    branches: [ main ]
+  pull_request:
     branches: [ main ]
  
 jobs:
@@ -46,8 +49,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        python3 -m pip install --upgrade pip
-        python3 -m pip install -e ".[dev]"
+        # debian:bookworm marks its system Python as externally managed
+        # (PEP 668), so pip refuses to install into it without this flag.
+        # This job builds docs in a throwaway container, so installing into
+        # system Python is fine and keeps sphinx on PATH for buildDocs.sh.
+        python3 -m pip install --upgrade --break-system-packages pip
+        python3 -m pip install --break-system-packages -e ".[dev]"
       shell: bash
 
     - name: Execute script to build our documentation and update pages


### PR DESCRIPTION
## Summary

Fixes the `docs_pages_workflow` failure that surfaced on `main` right after #200 merged.

**Two changes:**

1. **PEP 668 fix.** #200 moved the docs container off EOL `debian:buster` to `debian:bookworm`. Bookworm marks its system Python as *externally managed* (PEP 668), so `pip install` into it now fails with `error: externally-managed-environment`. Added `--break-system-packages` to the two `pip` calls — this job builds docs in a throwaway container, so a system-Python install is fine and keeps `sphinx` on `PATH` for `docs/buildDocs.sh`.
2. **Gate on PRs.** This workflow previously triggered only on `push` to `main`, so its failure was *not* among #200's PR checks and only appeared post-merge. Added a `pull_request: branches: [main]` trigger so a broken docs build blocks the PR going forward.

## Test plan

- This PR's own `pull_request` run of `docs_pages_workflow` is the live test — it must reach and pass the `Install phippery` step (previously the failure point) on `debian:bookworm`.

## Deviations from spec

None — this is a direct follow-up fix, no separate spec. Chose `--break-system-packages` over a venv because `buildDocs.sh` expects `sphinx` on the system PATH; a venv would require threading its activation through that script too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
