### PR TITLE
fix: revive Quay container build (dead ADD endpoint + py3.8 dep-rot)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM quay.io/hdc-workflows/ubuntu:20.04
+FROM ubuntu:22.04
 
-# bust cache
-ADD http://date.jsontest.com /etc/builddate
-
-LABEL maintainer "Jared Galloway <jgallowa@fredhutch.rg>" \
-      version "1.3.1" \
-      description "Common PhIP-Seq Workflows"
+LABEL maintainer="Jared Galloway <jgallowa@fredhutch.rg>" \
+      version="1.3.1" \
+      description="Common PhIP-Seq Workflows"
 
 # install needed tools
 RUN apt-get update --fix-missing -qq && \


### PR DESCRIPTION
## Summary

The Quay container build (`quay.io/hdc-workflows/phippery`) has been
failing — the README's container badge shows "building"/no-status. A full
local `docker build` reproduction found **two stacked failures**, both
fixed here:

**1. Dead `ADD` cache-bust endpoint (the immediate blocker).**
`ADD http://date.jsontest.com /etc/builddate` now returns **HTTP 403**;
Docker/Quay treat a non-200 on `ADD <url>` as a fatal build error, so the
build died at step 2/5 before installing anything. This is the "internal
system error after the ADD command" seen on Quay's manual build. Removed —
Docker already invalidates the cache on content change, so the manual bust
was both broken and unnecessary.

**2. Python 3.8 dependency rot (hidden behind #1).**
With the `ADD` line gone, the build reached the `pip install` step and
failed there: the base image `hdc-workflows/ubuntu:20.04` ships **Python
3.8**, which is *below* phippery's own `requires-python >=3.9`. On 3.8 the
`POT` dependency has no wheel and builds from source, where its
pre-Cython-3 `.pyx` fails to compile (`'ndarray' is not a type
identifier`, ~40 errors).

**Fix:** bump the base image to **`ubuntu:22.04`** (Python 3.10.12). This
matches phippery's Python floor *and* lets `POT` install a prebuilt
`cp310` wheel — no source compile, no Cython crash. Also modernized the
`LABEL` to the `key=value` form (Docker deprecated the legacy `key value`
form); bumpver's Dockerfile pattern is the bare `{version}`, so `1.3.1` is
still matched.

## Test plan

Verified locally end-to-end with `docker build --no-cache` (the current
`main` Dockerfile was reproduced failing first, then this version):

- ✓ Image builds green through the real `pip install git+…@1.3.1`
- ✓ `POT-0.9.7` installs as a **wheel** (was: source build → Cython crash)
- ✓ `docker run … python3 -c "import phippery"` → **1.3.1**
- ✓ `docker run … phippery --help` → CLI runs
- ✓ `docker run … python3 --version` → **Python 3.10.12** (≥ 3.9 floor)

Merging to `main` triggers a fresh Quay build, which is the real
end-to-end confirmation.

> Note: local repro was on arm64 (Apple Silicon); Quay builds amd64. The
> fix is architecture-independent — `POT` ships `cp310` manylinux wheels
> for both, so the "Python 3.10 → wheel, not source build" logic holds on
> Quay's x86_64 workers.

## Deviations from spec

This PR was scoped by a live decision (not a written issue spec). The user
asked to "remove the ADD line and push to main to test." During local
verification I found the second failure (POT/Cython on py3.8) and asked how
deep to fix; the user chose **"ADD + modern base image."** The `LABEL`
modernization was a minor, in-scope cleanup folded into the header change I
was already making. No other departures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
